### PR TITLE
Updated setting of site and root_url variables

### DIFF
--- a/invitation/models.py
+++ b/invitation/models.py
@@ -29,17 +29,9 @@ from django.db import connection
 if getattr(settings, 'INVITATION_USE_ALLAUTH', False):
     import re
     SHA1_RE = re.compile('^[a-f0-9]{40}$')
-else:    
+else:
     from registration.models import SHA1_RE
 
-# prevent error on initial syncdb for apps that incorporate django-invitaion
-try:
-    site = Site.objects.get_current()
-    root_url = 'http://%s' % site.domain
-except:
-    connection.close()
-
-    
 class InvitationKeyManager(models.Manager):
     def get_key(self, invitation_key):
         """
@@ -49,9 +41,9 @@ class InvitationKeyManager(models.Manager):
             key = self.get(key=invitation_key)
         except self.model.DoesNotExist:
             return None
-        
+
         return key
-        
+
     def is_key_valid(self, invitation_key):
         """
         Check if an ``InvitationKey`` is valid or not, returning a valid key
@@ -65,8 +57,8 @@ class InvitationKeyManager(models.Manager):
     def create_invitation(self, user, recipient=('recipient@email.com', 'Sirname', 'Lastname' ), save=True):
         """
         Create an ``InvitationKey`` and returns it.
-        
-        The key for the ``InvitationKey`` will be a SHA1 hash, generated 
+
+        The key for the ``InvitationKey`` will be a SHA1 hash, generated
         from a combination of the ``User``'s username and a random salt.
         """
         salt = sha_constructor(str(random.random())).hexdigest()[:5]
@@ -74,7 +66,7 @@ class InvitationKeyManager(models.Manager):
         if not save:
             return InvitationKey(from_user=user, key='previewkey00000000', recipient=recipient, date_invited=datetime.datetime.now())
         return self.create(from_user=user, key=key, recipient=recipient)
-    
+
     def create_bulk_invitation(self, user, key, uses, recipient):
         """ Create a set of invitation keys - these can be used by anyone, not just a specific recipient """
         return self.create(from_user=user, key=key, uses_left=uses, recipient=None)
@@ -96,43 +88,49 @@ class InvitationKeyManager(models.Manager):
 
 class InvitationKey(models.Model):
     key = models.CharField(_('invitation key'), max_length=40)
-    date_invited = models.DateTimeField(_('date invited'), 
+    date_invited = models.DateTimeField(_('date invited'),
                                         auto_now_add=True)
-    from_user = models.ForeignKey(User, 
+    from_user = models.ForeignKey(User,
                                   related_name='invitations_sent')
-    registrant = models.ManyToManyField(User, null=True, blank=True, 
+    registrant = models.ManyToManyField(User, null=True, blank=True,
                                   related_name='invitations_used')
     uses_left = models.IntegerField(default=1)
-    
+
     objects = InvitationKeyManager()
-    
+
     recipient = PickledObjectField(default=None, null=True)
-    
+
+    def __init__(self, *args, **kwargs):
+        super(InvitationKey, self).__init__(*args, **kwargs)
+        self.site = Site.objects.get_current()
+        self.root_url = 'http://%s' % self.site.domain
+
+
     def __unicode__(self):
         return u"Invitation from %s on %s (%s)" % (self.from_user.username, self.date_invited, self.key)
-    
+
     def is_usable(self):
         """
-        Return whether this key is still valid for registering a new user.        
+        Return whether this key is still valid for registering a new user.
         """
         return self.uses_left > 0 and not self.key_expired()
-    
+
     def key_expired(self):
         """
-        Determine whether this ``InvitationKey`` has expired, returning 
+        Determine whether this ``InvitationKey`` has expired, returning
         a boolean -- ``True`` if the key has expired.
-        
-        The date the key has been created is incremented by the number of days 
-        specified in the setting ``ACCOUNT_INVITATION_DAYS`` (which should be 
+
+        The date the key has been created is incremented by the number of days
+        specified in the setting ``ACCOUNT_INVITATION_DAYS`` (which should be
         the number of days after invite during which a user is allowed to
-        create their account); if the result is less than or equal to the 
+        create their account); if the result is less than or equal to the
         current date, the key has expired and this method returns ``True``.
-        
+
         """
         expiration_date = datetime.timedelta(days=settings.ACCOUNT_INVITATION_DAYS)
         return self.date_invited + expiration_date <= now()
     key_expired.boolean = True
-    
+
     def mark_used(self, registrant):
         """
         Note that this key has been used to register a new user.
@@ -141,28 +139,28 @@ class InvitationKey(models.Model):
         self.registrant.add(registrant)
         default_storage.delete('tokens/%s.png' % self.key)
         self.save()
-    
+
     def get_context(self, sender_note=None):
-        invitation_url = root_url + reverse('invitation_invited', kwargs={'invitation_key':self.key})
+        invitation_url = self.root_url + reverse('invitation_invited', kwargs={'invitation_key':self.key})
         exp_date = self.date_invited + datetime.timedelta(days=settings.ACCOUNT_INVITATION_DAYS)
         context = { 'invitation_key': self,
                     'expiration_days': settings.ACCOUNT_INVITATION_DAYS,
                     'from_user': self.from_user,
                     'sender_note': sender_note,
-                    'site': site,
-                    'root_url': root_url,
+                    'site': self.site,
+                    'root_url': self.root_url,
                     'expiration_date': exp_date,
                     'recipient': self.recipient,
                     'token': self.generate_token(invitation_url),
                     'invitation_url':invitation_url}
         return context
-    
+
     def send_to(self, from_email=settings.DEFAULT_FROM_EMAIL, sender_note=None,):
         """
         Send an invitation email to ``email``.
         """
         context = self.get_context(sender_note)
-        
+
         subject = render_to_string('invitation/invitation_email_subject.txt', context)
         # Email subject *must not* contain newlines
         subject = ''.join(subject.splitlines())
@@ -173,7 +171,7 @@ class InvitationKey(models.Model):
         msg = EmailMultiAlternatives(subject, message, from_email, [self.recipient[0]])
         msg.attach_alternative(message_html, "text/html")
         msg.send()
-    
+
     def generate_token(self, invitation_url):
         def stamp(image, text, offset):
             f = ImageFont.load_default()
@@ -187,16 +185,16 @@ class InvitationKey(models.Model):
             y = ih/2 - th/2
             image.paste( exp_img_r, (x,y+offset), exp_img_r)
             return offset+th
-        
+
         #normalize sataic url
-        r_parse = urlparse(root_url, 'http')
+        r_parse = urlparse(self.root_url, 'http')
         s_parse = urlparse(settings.STATIC_URL, 'http')
         s_parts = (s_parse.scheme, s_parse.netloc or r_parse.netloc, s_parse.path, s_parse.params, s_parse.query, s_parse.fragment)
         static_url = urlunparse(s_parts)
-        
+
         #open base token image
         img_url = static_url+'notification/img/token-invite.png'
-        temp_img = NamedTemporaryFile()    
+        temp_img = NamedTemporaryFile()
         temp_img.write(urllib2.urlopen(img_url).read())
         temp_img.flush()
         image = Image.open(temp_img.name)
@@ -214,10 +212,10 @@ class InvitationKey(models.Model):
         image.save(temp_img.name, "PNG", quality=95)
         if not default_storage.exists('tokens/%s.png' % self.key):
             default_storage.save('tokens/%s.png' % self.key, File(temp_img))
-        get_token_url = root_url+reverse('invitation_token', kwargs={'key':self.key})
+        get_token_url = self.root_url+reverse('invitation_token', kwargs={'key':self.key})
         token_html = '<a style="display: inline-block;" href="'+invitation_url+'"><img width="100" height="100" class="token" src="'+get_token_url+'" alt="invitation token"></a>'
         return token_html
-        
+
 class InvitationUser(models.Model):
     inviter = models.ForeignKey(User, unique=True)
     invitations_remaining = models.IntegerField()
@@ -225,7 +223,7 @@ class InvitationUser(models.Model):
     def __unicode__(self):
         return u"InvitationUser for %s" % self.inviter.username
 
-    
+
 def user_post_save(sender, instance, created, **kwargs):
     """Create InvitationUser for user when User is created."""
     if created:
@@ -258,3 +256,4 @@ def invitation_key_pre_delete(sender, instance, **kwargs):
         pass
 
 models.signals.post_delete.connect(invitation_key_pre_delete, sender=InvitationKey)
+


### PR DESCRIPTION
In https://github.com/arctelix/django-invitation/blob/master/invitation/models.py the statement `site = Site.objects.get_current()` results in an exception `AppRegistryNotReady: Models aren't loaded yet.` being raised on Django 1.7, which means `site` and `root_url` are never set. 

The changes proposed with this pull request move those two variables inside the InvitationKey class. Also included a little cleanup for spacing and line lengths.
